### PR TITLE
fix 0-byte objects upload

### DIFF
--- a/ftpcloudfs/chunkobject.py
+++ b/ftpcloudfs/chunkobject.py
@@ -66,6 +66,9 @@ class ChunkObject(object):
             logging.debug("ChunkObject: already sent %s bytes" % self.already_sent)
 
     def finish_chunk(self):
+        if self.raw_conn is None:
+            self._open_connection()
+
         logging.debug("ChunkObject: finish_chunk")
         try:
             self.raw_conn.send("0\r\n\r\n")


### PR DESCRIPTION
My previous pull request introduced not only improvements, but also bug.
When uploading 0-byte object to ftp-proxy `raw_connection` isn't open. And when `finish_chunk` executed we get error: `'NoneType' object has no attribute 'send'`.
Sorry for that :-(