### PR TITLE
Split large file collisions

### DIFF
--- a/ftpcloudfs/fs.py
+++ b/ftpcloudfs/fs.py
@@ -293,9 +293,10 @@ class ObjectStorageFD(object):
         """Close the object and finish the data transfer."""
         if 'r' not in self.mode:
             if self.pending_copy_task:
-                logging.debug("waiting for a pending copy task...")
-                self.pending_copy_task.join()
-                logging.debug("wait is over")
+                if self.pending_copy_task.is_alive():
+                    logging.debug("waiting for a pending copy task...")
+                    self.pending_copy_task.join()
+                    logging.debug("wait is over")
                 if self.pending_copy_task.exitcode != 0:
                     raise IOSError(EIO, 'Failed to store the file')
             if self.obj is not None:


### PR DESCRIPTION
Without checking manifest object existence we can be sure, that newly uploaded object will exactly that it should be. For example, if we first upload 100Mb object and that re-upload it with 90Mb object, swift will server 100Mb on GET requests (that's how DLO works).
So, without checking manifest, we create new .part "directory", if rewrite large object. Old .part "directory" will remain in storage and visible in FTP's directory listing.

Also, without checking manifest, we can check for collisions just once right after first part was uploaded.