### PR TITLE
Keystone auth v3 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,10 @@ Options:
   --keystone-tenant-separator=TENANT_SEPARATOR
                         Character used to separate tenant_name/username in
                         Keystone auth (default: TENANT.USERNAME)
+  --keystone-domain-separator=DOMAIN_SEPARATOR
+                        Character used to separate project_name/project_domain_name
+                        and username/user_domain_name in Keystone auth v3
+                        (default: @)
   --keystone-service-type=SERVICE_TYPE
                         Service type to be used in Keystone auth (default:
                         object-store)
@@ -146,8 +150,11 @@ Optionally `OpenStack Identity Service`_ (Keystone) v2.0 or v3 can be used.
 Currently python-keystoneclient (0.3.2+ recommended) is required to use Keystone auth
 and it can be enabled with ``keystone-auth`` option.
 
-You can provide a tenant name in the FTP login user with TENANT.USERNAME (using a dot as
-separator). Please check the example configuration file for further details.
+With Keystone v2.0, you can provide a tenant name in the FTP login user with
+TENANT.USERNAME (using a dot as separator).
+With Keystone v3, you can also provide domain name in the FTP login user with
+PROJECT_NAME@PROJECT_DOMAIN_NAME.USERNAME@USER_DOMAIN_NAME (using @ as a separator).
+Please check the example configuration file for further details.
 
 .. _swauth: https://github.com/gholt/swauth
 .. _OpenStack Identity Service: https://developer.openstack.org/api-ref/identity/index.html

--- a/README.rst
+++ b/README.rst
@@ -96,17 +96,19 @@ Options:
   --pid-file=PID_FILE   Pid file location when in daemon mode
   --uid=UID             UID to drop the privilige to when in daemon mode
   --gid=GID             GID to drop the privilige to when in daemon mode
-  --keystone-auth       Use auth 2.0 (Keystone, requires keystoneclient)
+  --keystone-auth       Use OpenStack Identity Service (Keystone, requires keystoneclient)
+  --keystone-auth-version=VERSION
+                        Identity API version to be used (default: 2.0)
   --keystone-region-name=REGION_NAME
-                        Region name to be used in auth 2.0
+                        Region name to be used in Keystone auth
   --keystone-tenant-separator=TENANT_SEPARATOR
                         Character used to separate tenant_name/username in
-                        auth 2.0 (default: TENANT.USERNAME)
+                        Keystone auth (default: TENANT.USERNAME)
   --keystone-service-type=SERVICE_TYPE
-                        Service type to be used in auth 2.0 (default: object-
-                        store)
+                        Service type to be used in Keystone auth (default:
+                        object-store)
   --keystone-endpoint-type=ENDPOINT_TYPE
-                        Endpoint type to be used in auth 2.0 (default:
+                        Endpoint type to be used in Keystone auth (default:
                         publicURL)
 
 The defaults can be changed using a configuration file (by default in
@@ -133,21 +135,22 @@ possible to associate a token with a specific user (not trivial) or even use the
 cache key (MD5 hash) to brute-force the user password.
 
 
-AUTH 2.0
+OPENSTACK IDENTITY SERVICE (KEYSTONE)
 ========
 
 By default ftp-cloudfs will use Swift auth 1.0, that is compatible with `OpenStack Object Storage`
 using `swauth`_ auth middleware and Swift implementations such as `Rackspace Cloud Files` or
 `Memset's Memstore Cloud Storage`.
 
-Optionally `OpenStack Identity Service 2.0`_ can be used. Currently python-keystoneclient (0.3.2+
-recommended) is required to use auth 2.0 and it can be enabled with ``keystone-auth`` option.
+Optionally `OpenStack Identity Service`_ (Keystone) v2.0 or v3 can be used.
+Currently python-keystoneclient (0.3.2+ recommended) is required to use Keystone auth
+and it can be enabled with ``keystone-auth`` option.
 
 You can provide a tenant name in the FTP login user with TENANT.USERNAME (using a dot as
 separator). Please check the example configuration file for further details.
 
 .. _swauth: https://github.com/gholt/swauth
-.. _OpenStack Identity Service 2.0: http://docs.openstack.org/api/openstack-identity-service/2.0/content/index.html
+.. _OpenStack Identity Service: https://developer.openstack.org/api-ref/identity/index.html
 .. _RackSpace Cloud Files: http://www.rackspace.com/cloud/cloud_hosting_products/files/
 .. _Memset's Memstore Cloud Storage: https://www.memset.com/cloud/storage/
 

--- a/ftpcloudfs.conf.example
+++ b/ftpcloudfs.conf.example
@@ -82,6 +82,10 @@
 # Tenant separator to be used with Keystone auth (eg. TENANT.USERNAME)
 # keystone-tenant-separator = .
 
+# Domain separator to be used with Keystone auth v3 only
+# (eg. PROJECT_NAME@PROJECT_DOMAIN_NAME.USERNAME@USER_DOMAIN_NAME)
+# keystone-domain-separator = @
+
 # Service type to be used with Keystone auth.
 # keystone-service-type = object-store
 

--- a/ftpcloudfs.conf.example
+++ b/ftpcloudfs.conf.example
@@ -70,19 +70,22 @@
 # By default the operating system will assign a port.
 # passive-ports = (empty)
 
-# Auth 2.0 (Keystone), requires keystoneclient
+# Use OpenStack Identity Service (Keystone), requires keystoneclient.
 # keystone-auth = no
 
-# Region name to be used with Auth 2.0 (optional)
+# Identity API version to be used with Keystone auth..
+# keystone-auth-version = 2.0
+
+# Region name to be used with Keystone auth (optional)
 # keystone-region-name = (empty)
 
-# Tenant separator to be used with Auth 2.0 (eg. TENANT.USERNAME)
+# Tenant separator to be used with Keystone auth (eg. TENANT.USERNAME)
 # keystone-tenant-separator = .
 
-# Service type to be used with Auth 2.0.
+# Service type to be used with Keystone auth.
 # keystone-service-type = object-store
 
-# Endpoint type to be used with Auth 2.0.
+# Endpoint type to be used with Keystone auth.
 # keystone-endpoint-type = publicURL
 
 # Use Rackspace's ServiceNet internal network.

--- a/ftpcloudfs/fs.py
+++ b/ftpcloudfs/fs.py
@@ -671,7 +671,7 @@ class ObjectStorageFS(object):
         username - if None then don't make the connection (delayed auth)
         api_key
         authurl
-        keystone - optional for auth 2.0 (keystone)
+        keystone - optional, use Openstack Identity service (Keystone)
         hider_part_dirt - optional, hide multipart .part files
         snet - optional, use Rackspace's service network
         insecure - optional, allow using servers without checking their SSL certs
@@ -704,12 +704,19 @@ class ObjectStorageFS(object):
             logging.debug("keystone authurl=%r username=%r tenant_name=%r conf=%r" % (self.authurl, username, tenant_name, self.keystone))
 
             ks = self.keystone
-            kwargs["auth_version"] = "2.0"
-            kwargs["tenant_name"] = tenant_name
-            kwargs["os_options"] = dict(service_type=ks['service_type'],
-                                        endpoint_type=ks['endpoint_type'],
-                                        region_name=ks['region_name'],
-                                        )
+            kwargs["auth_version"] = ks['auth_version']
+            if ks['auth_version'] == "3":
+                kwargs["os_options"] = dict(service_type=ks['service_type'],
+                                            endpoint_type=ks['endpoint_type'],
+                                            region_name=ks['region_name'],
+                                            project_name=tenant_name,
+                                            )
+            else:
+                kwargs["tenant_name"] = tenant_name
+                kwargs["os_options"] = dict(service_type=ks['service_type'],
+                                            endpoint_type=ks['endpoint_type'],
+                                            region_name=ks['region_name'],
+                                            )
 
         self.conn = ProxyConnection(self._listdir_cache.memcache,
                                     user=username,

--- a/ftpcloudfs/main.py
+++ b/ftpcloudfs/main.py
@@ -124,6 +124,7 @@ class Main(object):
                                   'keystone-auth-version': '2.0',
                                   'keystone-region-name': None,
                                   'keystone-tenant-separator': default_ks_tenant_separator,
+                                  'keystone-domain-separator': '@',
                                   'keystone-service-type': default_ks_service_type,
                                   'keystone-endpoint-type': default_ks_endpoint_type,
                                   'rackspace-service-net' : 'no',
@@ -249,6 +250,13 @@ class Main(object):
                           help="Character used to separate tenant_name/username in Keystone auth" + \
                               " (default: TENANT%sUSERNAME)" % default_ks_tenant_separator)
 
+        parser.add_option('--keystone-domain-separator',
+                          type="str",
+                          dest="domain_separator",
+                          default=self.config.get('ftpcloudfs', 'keystone-domain-separator'),
+                          help="Character used to separate project_name/project_domain_name " + \
+                               "and username/user_domain_name in Keystone auth v3 (default: @)")
+
         parser.add_option('--keystone-service-type',
                           type="str",
                           dest="service_type",
@@ -277,7 +285,7 @@ class Main(object):
                     from keystoneclient.v2_0 import client as _test_ksclient
             except ImportError:
                 parser.error("OpenStack Identity Service (keystone) requires python-keystoneclient.")
-            keystone_keys = ('auth_version', 'region_name', 'tenant_separator', 'service_type', 'endpoint_type')
+            keystone_keys = ('auth_version', 'region_name', 'tenant_separator', 'domain_separator', 'service_type', 'endpoint_type')
             options.keystone = dict((key, getattr(options, key)) for key in keystone_keys)
 
         if not options.authurl:

--- a/ftpcloudfs/main.py
+++ b/ftpcloudfs/main.py
@@ -119,8 +119,9 @@ class Main(object):
                                   'passive-ports': None,
                                   'split-large-files': '0',
                                   'hide-part-dir': 'no',
-                                  # keystone auth 2.0 support
+                                  # keystone auth support
                                   'keystone-auth': False,
+                                  'keystone-auth-version': '2.0',
                                   'keystone-region-name': None,
                                   'keystone-tenant-separator': default_ks_tenant_separator,
                                   'keystone-service-type': default_ks_service_type,
@@ -227,32 +228,38 @@ class Main(object):
                           action="store_true",
                           dest="keystone",
                           default=self.config.get('ftpcloudfs', 'keystone-auth'),
-                          help="Use auth 2.0 (Keystone, requires keystoneclient)")
+                          help="Use OpenStack Identity Service (Keystone, requires keystoneclient)")
+
+        parser.add_option('--keystone-auth-version',
+                          type="str",
+                          dest="auth_version",
+                          default=self.config.get('ftpcloudfs', 'keystone-auth-version'),
+                          help="Identity API version to be used (default: 2.0)")
 
         parser.add_option('--keystone-region-name',
                           type="str",
                           dest="region_name",
                           default=self.config.get('ftpcloudfs', 'keystone-region-name'),
-                          help="Region name to be used in auth 2.0")
+                          help="Region name to be used in Keystone auth")
 
         parser.add_option('--keystone-tenant-separator',
                           type="str",
                           dest="tenant_separator",
                           default=self.config.get('ftpcloudfs', 'keystone-tenant-separator'),
-                          help="Character used to separate tenant_name/username in auth 2.0" + \
+                          help="Character used to separate tenant_name/username in Keystone auth" + \
                               " (default: TENANT%sUSERNAME)" % default_ks_tenant_separator)
 
         parser.add_option('--keystone-service-type',
                           type="str",
                           dest="service_type",
                           default=self.config.get('ftpcloudfs', 'keystone-service-type'),
-                          help="Service type to be used in auth 2.0 (default: %s)" % default_ks_service_type)
+                          help="Service type to be used in Keystone auth (default: %s)" % default_ks_service_type)
 
         parser.add_option('--keystone-endpoint-type',
                           type="str",
                           dest="endpoint_type",
                           default=self.config.get('ftpcloudfs', 'keystone-endpoint-type'),
-                          help="Endpoint type to be used in auth 2.0 (default: %s)" % default_ks_endpoint_type)
+                          help="Endpoint type to be used in Keystone auth (default: %s)" % default_ks_endpoint_type)
 
         parser.add_option('--config',
                           type="str",
@@ -264,10 +271,13 @@ class Main(object):
 
         if options.keystone:
             try:
-                from keystoneclient.v2_0 import client as _test_ksclient
+                if getattr(options, 'auth_version') == '3':
+                    from keystoneclient.v3 import client as _test_ksclient
+                else:
+                    from keystoneclient.v2_0 import client as _test_ksclient
             except ImportError:
-                parser.error("Auth 2.0 (keystone) requires python-keystoneclient.")
-            keystone_keys = ('region_name', 'tenant_separator', 'service_type', 'endpoint_type')
+                parser.error("OpenStack Identity Service (keystone) requires python-keystoneclient.")
+            keystone_keys = ('auth_version', 'region_name', 'tenant_separator', 'service_type', 'endpoint_type')
             options.keystone = dict((key, getattr(options, key)) for key in keystone_keys)
 
         if not options.authurl:


### PR DESCRIPTION
This PR adds support for OpenStack Identity Service (Keystone) v3.
```keystone-auth-version``` parameter is optional and defaults to 2.0 so it will not break existing installations during upgrade.

Fix for Issues #18 and #66