### PR TITLE
Add Swift storage policies support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,9 @@ Options:
   --keystone-endpoint-type=ENDPOINT_TYPE
                         Endpoint type to be used in Keystone auth (default:
                         publicURL)
+  --storage-policy=STORAGE_POLICY
+                        Swift storage policy to be used (optional)
+                        Access to other containers will be denied
 
 The defaults can be changed using a configuration file (by default in
 /etc/ftpcloudfs.conf). Check the example file included in the package.
@@ -178,6 +181,21 @@ store the manifest. If the original file is downloaded, the parts will be served
 The *FILE.part* directory can be removed from directory listings using the *hide-part-dir* configuration
 token. Please be aware that the directory will still be visible when accessing the storage using
 swift API.
+
+
+STORAGE POLICIES
+================
+
+Swift storage policies may be used to add some level of segmentation inside a single Swift cluster :
+durability levels (Replication / Erasure Coding), storage backend performance (SSD vs HDD), ...
+
+With storage_policy paramter, you can restrict user access to a single policy : If no name is specified,
+the default policy is used (and if no other policies, defined Policy-0 is considered the default).
+Policy-0 is what is used by Swift when accessing pre-storage-policy containers which won’t have a policy.
+
+See `Openstack Storage Policies` for implementation details.
+
+.. _Openstack Storage Policies: https://docs.openstack.org/swift/latest/overview_policies.html
 
 
 SUPPORT

--- a/ftpcloudfs.conf.example
+++ b/ftpcloudfs.conf.example
@@ -95,4 +95,8 @@
 # Use Rackspace's ServiceNet internal network.
 # rackspace-service-net = no
 
+# Swift storage policy to be used (optional)
+# Access to other containers will be denied
+# storage-policy = (empty)
+
 # EOF

--- a/ftpcloudfs/main.py
+++ b/ftpcloudfs/main.py
@@ -128,6 +128,7 @@ class Main(object):
                                   'keystone-service-type': default_ks_service_type,
                                   'keystone-endpoint-type': default_ks_endpoint_type,
                                   'rackspace-service-net' : 'no',
+                                  'storage-policy' : None,
                                  })
 
         try:
@@ -269,6 +270,12 @@ class Main(object):
                           default=self.config.get('ftpcloudfs', 'keystone-endpoint-type'),
                           help="Endpoint type to be used in Keystone auth (default: %s)" % default_ks_endpoint_type)
 
+        parser.add_option('--storage-policy',
+                          type="str",
+                          dest="storage_policy",
+                          default=self.config.get('ftpcloudfs', 'storage-policy'),
+                          help="Allowed Swift storage policy")
+
         parser.add_option('--config',
                           type="str",
                           dest="config",
@@ -304,6 +311,7 @@ class Main(object):
         ObjectStorageFtpFS.insecure = self.options.insecure
         ObjectStorageFtpFS.keystone = self.options.keystone
         ObjectStorageFtpFS.memcache_hosts = self.options.memcache
+        ObjectStorageFtpFS.storage_policy = self.options.storage_policy
         ObjectStorageFtpFS.hide_part_dir = self.config.getboolean('ftpcloudfs', 'hide-part-dir')
         ObjectStorageFtpFS.snet = self.config.getboolean('ftpcloudfs', 'rackspace-service-net')
 

--- a/ftpcloudfs/server.py
+++ b/ftpcloudfs/server.py
@@ -18,8 +18,9 @@ class ObjectStorageFtpFS(ObjectStorageFS, AbstractedFS):
     keystone = None
     hide_part_dir = None
     snet = False
+    storage_policy = None
 
-    def __init__(self, username, api_key, authurl=None, keystone=None, hide_part_dir=None):
+    def __init__(self, username, api_key, authurl=None, keystone=None, hide_part_dir=None, storage_policy=None):
         ObjectStorageFS.__init__(self,
                                  username,
                                  api_key,
@@ -28,6 +29,7 @@ class ObjectStorageFtpFS(ObjectStorageFS, AbstractedFS):
                                  hide_part_dir=hide_part_dir or self.hide_part_dir,
                                  snet = self.snet,
                                  insecure = self.insecure,
+                                 storage_policy=storage_policy,
                                  )
 
     def init_abstracted_fs(self, root, cmd_channel):


### PR DESCRIPTION
Since we're operating a multi-policy Swift cluster, we needed a way to filter (s)ftp access to a custom policy. Thanks to Swift [Storage Policies](https://docs.openstack.org/swift/latest/overview_policies.html), we just need to add a custom `X-Storage-Policy` HTTP header to all Swift requests to do it !