### PR TITLE
Fix token caching with Keystone auth v3

### DIFF
--- a/ftpcloudfs/fs.py
+++ b/ftpcloudfs/fs.py
@@ -48,6 +48,8 @@ class ProxyConnection(Connection):
         self.tenant_name = None
         if kwargs.get('auth_version') == "2.0":
             self.tenant_name = kwargs['tenant_name']
+        if kwargs.get('auth_version') == "3":
+            self.tenant_name = kwargs['os_options']['project_name']
         super(ProxyConnection, self).__init__(*args, **kwargs)
 
     def http_connection(self):


### PR DESCRIPTION
```self.tenant_name``` is not set if using Keystone auth v3 (used to build memcache key name)